### PR TITLE
feat: scale the number of workers based on the number of messages in all the queues

### DIFF
--- a/helm/templates/rabbitmq-hpa.tpl
+++ b/helm/templates/rabbitmq-hpa.tpl
@@ -1,12 +1,12 @@
-# Define the secret containing the AMQP URL.
+# Define the secret containing the RabbitMQ HTTP URL.
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-keda-rabbitmq-secret
 data:
-  # The AMQP URL should be encoded using base64.
+  # The URL should be encoded using base64.
   # TODO: Implement a more robust secret management system to enhance security.
-  AMQP_URL: {{ printf "amqp://%s:%s@%s-rabbitmq-cluster.%s.svc.cluster.local:5672" .Values.rabbitmq.cluster.username .Values.rabbitmq.cluster.password .Release.Name .Release.Namespace | b64enc }}
+  host: {{ printf "http://%s:%s@%s-rabbitmq-cluster.%s.svc.cluster.local:15672/" .Values.rabbitmq.cluster.username .Values.rabbitmq.cluster.password .Release.Name .Release.Namespace | b64enc }}
 
 ---
 # Describe which secret the ScaledObject will use.
@@ -27,8 +27,8 @@ spec:
       # The name of the secret resource.
       # It should be in the same namespace as the ScaledObject.
       name: {{ .Release.Name }}-keda-rabbitmq-secret
-      # The name of the key that contains the AMQP URL.
-      key: AMQP_URL
+      # The name of the key that contains the HTTP URL.
+      key: host
 
 ---
 # Define which resource the HPA will scale and how it will scale it.
@@ -108,16 +108,21 @@ spec:
   - type: rabbitmq
     metadata:
       # The protocol to be used for communication.
-      protocol: amqp
+      protocol: http
+      # Use regex to select queue instead of full name.
+      # Note: Only applies to host that use the http protocol.
+      useRegex: "true"
       # The name of the RabbitMQ queue.
       # Proof generation tasks each create their own queue, so rather than targeting a specific queue,
       # this setting applies to all queues created within the RabbitMQ cluster.
-      queueName: .*
+      queueName: ^.*$
+      # Operation that will be applied to compute the number of messages in case of useRegex enabled.
+      operation: sum
       # The trigger mode. We chose to trigger on number of messages in the queue.
       mode: QueueLength
       # The message backlog to trigger on.
       # It must be a string.
-      value: "20"
+      value: "2"
     authenticationRef:
       # The name of the TriggerAuthentication object.
       name: {{ .Release.Name }}-keda-trigger-auth-rabbitmq-conn


### PR DESCRIPTION
When testing, I created a dummy queue and added messages. The HPA would then schedule new worker pods based on the size of the queue (e.g. if the queue grows by 20 messages, schedule a new worker pod, up to a limit of `x` pods). But the problem is that paladin-leader creates a queue for each proof generation request (am I wrong?). There is a way to use a regex in the RabbitMQ Queue (HPA) and to do a sum of all the queues length so we should better use this and test that it works well.