### PR TITLE
Terraform scripts template to setup minimal GKE environment for testing 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,31 @@ A Helm chart to deploy Polygon Zero's [Type 1 Prover](https://github.com/0xPolyg
 
 ![architecture-diagram](./docs/architecture-diagram.png)
 
+## Deploying GKE with Terraform
+
+The below GKE infrastructure requirement can be automated using the provided terraform scripts under `/terraform` directory.
+
+```!
+# First authenticate with your GCP account
+gcloud auth application-default login
+
+# Check which project is active and switch as necessary under /terraform/variables.tf
+gcloud config get-value project
+
+# Once all the deployment variables have been declared under /terraform/variables.tf start the terraform deployment
+terraform init
+
+# Check the predicted deployment outputs
+terraform plan
+
+# Deploy the infrastructure
+terraform apply
+```
+
+With the above instructions, you should have a setup which mimics the below requirement:
+- A VPC and a subnet
+- GKE cluster and a separately managed node pool
+
 ## Usage
 
 To be able to run the type 1 prover infrastructure, you will need:

--- a/terraform/gke.tf
+++ b/terraform/gke.tf
@@ -1,16 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
-variable "gke_username" {
-  default     = ""
-  description = "gke username"
-}
-
-variable "gke_password" {
-  default     = ""
-  description = "gke password"
-}
-
 variable "gke_num_nodes" {
   default     = 1
   description = "number of gke nodes"
@@ -93,22 +80,3 @@ resource "google_container_node_pool" "highmem_nodes" {
     }
   }
 }
-
-# # Kubernetes provider
-# # The Terraform Kubernetes Provider configuration below is used as a learning reference only. 
-# # It references the variables and resources provisioned in this file. 
-# # We recommend you put this in another file -- so you can have a more modular configuration.
-# # https://learn.hashicorp.com/terraform/kubernetes/provision-gke-cluster#optional-configure-terraform-kubernetes-provider
-# # To learn how to schedule deployments and services using the provider, go here: https://learn.hashicorp.com/tutorials/terraform/kubernetes-provider.
-
-# provider "kubernetes" {
-#   load_config_file = "false"
-
-#   host     = google_container_cluster.primary.endpoint
-#   username = var.gke_username
-#   password = var.gke_password
-
-#   client_certificate     = google_container_cluster.primary.master_auth.0.client_certificate
-#   client_key             = google_container_cluster.primary.master_auth.0.client_key
-#   cluster_ca_certificate = google_container_cluster.primary.master_auth.0.cluster_ca_certificate
-# }

--- a/terraform/gke.tf
+++ b/terraform/gke.tf
@@ -1,0 +1,114 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+variable "gke_username" {
+  default     = ""
+  description = "gke username"
+}
+
+variable "gke_password" {
+  default     = ""
+  description = "gke password"
+}
+
+variable "gke_num_nodes" {
+  default     = 1
+  description = "number of gke nodes"
+}
+
+# GKE cluster
+data "google_container_engine_versions" "gke_version" {
+  location = var.region
+  # version_prefix = "1.27."
+}
+
+resource "google_container_cluster" "primary" {
+  name     = "${var.project_id}-zero-prover-gke"
+  location = var.region
+
+  # We can't create a cluster with no node pool defined, but we want to only use
+  # separately managed node pools. So we create the smallest possible default
+  # node pool and immediately delete it.
+  remove_default_node_pool = true
+  initial_node_count = 1
+
+  network    = google_compute_network.vpc.name
+  subnetwork = google_compute_subnetwork.subnet.name
+}
+
+# Separately Managed Default Node Pool
+resource "google_container_node_pool" "default_nodes" {
+  name       = "default-nodes-pool"
+  location   = var.region
+  cluster    = google_container_cluster.primary.name
+  node_locations = [ "europe-west3-c" ]
+
+  # version = data.google_container_engine_versions.gke_version.release_channel_latest_version["STABLE"]
+  node_count = var.gke_num_nodes
+
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+
+    labels = {
+      env = var.project_id
+    }
+
+    # preemptible  = true
+    machine_type = "e2-standard-16"
+    tags         = ["zero-prover-gke-node", "${var.project_id}-zero-prover-gke"]
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+  }
+}
+
+# Separately Managed Highmem Node Pool
+resource "google_container_node_pool" "highmem_nodes" {
+  name       = "highmem-nodes-pool"
+  location   = var.region
+  cluster    = google_container_cluster.primary.name
+  node_locations = [ "europe-west3-c" ]
+  
+  # version = data.google_container_engine_versions.gke_version.release_channel_latest_version["STABLE"]
+  node_count = var.gke_num_nodes
+
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+
+    labels = {
+      env = var.project_id
+    }
+
+    # preemptible  = true
+    machine_type = "t2d-standard-32"
+    tags         = ["zero-prover-gke-node", "${var.project_id}-zero-prover-gke"]
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+  }
+}
+
+# # Kubernetes provider
+# # The Terraform Kubernetes Provider configuration below is used as a learning reference only. 
+# # It references the variables and resources provisioned in this file. 
+# # We recommend you put this in another file -- so you can have a more modular configuration.
+# # https://learn.hashicorp.com/terraform/kubernetes/provision-gke-cluster#optional-configure-terraform-kubernetes-provider
+# # To learn how to schedule deployments and services using the provider, go here: https://learn.hashicorp.com/tutorials/terraform/kubernetes-provider.
+
+# provider "kubernetes" {
+#   load_config_file = "false"
+
+#   host     = google_container_cluster.primary.endpoint
+#   username = var.gke_username
+#   password = var.gke_password
+
+#   client_certificate     = google_container_cluster.primary.master_auth.0.client_certificate
+#   client_key             = google_container_cluster.primary.master_auth.0.client_key
+#   cluster_ca_certificate = google_container_cluster.primary.master_auth.0.cluster_ca_certificate
+# }

--- a/terraform/gke.tf
+++ b/terraform/gke.tf
@@ -1,8 +1,3 @@
-variable "gke_num_nodes" {
-  default     = 1
-  description = "number of gke nodes"
-}
-
 # GKE cluster
 data "google_container_engine_versions" "gke_version" {
   location = var.region
@@ -28,7 +23,7 @@ resource "google_container_node_pool" "default_nodes" {
   name       = "default-nodes-pool"
   location   = var.region
   cluster    = google_container_cluster.primary.name
-  node_locations = [ "europe-west3-c" ]
+  node_locations = var.node_locations
 
   # version = data.google_container_engine_versions.gke_version.release_channel_latest_version["STABLE"]
   node_count = var.gke_num_nodes
@@ -44,7 +39,7 @@ resource "google_container_node_pool" "default_nodes" {
     }
 
     # preemptible  = true
-    machine_type = "e2-standard-16"
+    machine_type = var.default_node_type
     tags         = ["zero-prover-gke-node", "${var.project_id}-zero-prover-gke"]
     metadata = {
       disable-legacy-endpoints = "true"
@@ -57,7 +52,7 @@ resource "google_container_node_pool" "highmem_nodes" {
   name       = "highmem-nodes-pool"
   location   = var.region
   cluster    = google_container_cluster.primary.name
-  node_locations = [ "europe-west3-c" ]
+  node_locations = var.node_locations
   
   # version = data.google_container_engine_versions.gke_version.release_channel_latest_version["STABLE"]
   node_count = var.gke_num_nodes
@@ -73,7 +68,7 @@ resource "google_container_node_pool" "highmem_nodes" {
     }
 
     # preemptible  = true
-    machine_type = "t2d-standard-32"
+    machine_type = var.highmem_node_type
     tags         = ["zero-prover-gke-node", "${var.project_id}-zero-prover-gke"]
     metadata = {
       disable-legacy-endpoints = "true"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,22 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+output "region" {
+  value       = var.region
+  description = "GCloud Region"
+}
+
+output "project_id" {
+  value       = var.project_id
+  description = "GCloud Project ID"
+}
+
+output "kubernetes_cluster_name" {
+  value       = google_container_cluster.primary.name
+  description = "GKE Cluster Name"
+}
+
+output "kubernetes_cluster_host" {
+  value       = google_container_cluster.primary.endpoint
+  description = "GKE Cluster Host"
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 output "region" {
   value       = var.region
   description = "GCloud Region"

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,2 +1,0 @@
-project_id = "jihwan-cdk-test"
-region     = "europe-west3"

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,5 +1,2 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 project_id = "jihwan-cdk-test"
 region     = "europe-west3"

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,0 +1,5 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+project_id = "jihwan-cdk-test"
+region     = "europe-west3"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,25 @@
+variable "project_id" {
+  type    = string
+  default = "jihwan-cdk-test"
+}
+variable "gke_num_nodes" {
+  default     = 1
+  description = "number of gke nodes"
+}
+variable "region" {
+  type    = string
+  default = "europe-west3"
+}
+variable "default_node_type" {
+  type    = string
+  default = "e2-standard-16"
+}
+variable "highmem_node_type" {
+  type    = string
+  default = "t2d-standard-32"
+}
+variable "node_locations" {
+  description = "List of availability zones within the region"
+  type        = list(string)
+  default     = ["europe-west2-c"]
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -21,5 +21,5 @@ variable "highmem_node_type" {
 variable "node_locations" {
   description = "List of availability zones within the region"
   type        = list(string)
-  default     = ["europe-west2-c"]
+  default     = ["europe-west3-c"]
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,14 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "4.74.0"
+    }
+  }
+
+  required_version = ">= 0.14"
+}
+

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 terraform {
   required_providers {
     google = {

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 variable "project_id" {
   description = "project id"
 }

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,11 +1,3 @@
-variable "project_id" {
-  description = "project id"
-}
-
-variable "region" {
-  description = "region"
-}
-
 provider "google" {
   project = var.project_id
   region  = var.region

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -14,5 +14,5 @@ resource "google_compute_subnetwork" "subnet" {
   name          = "${var.project_id}-zero-prover-subnet"
   region        = var.region
   network       = google_compute_network.vpc.name
-  ip_cidr_range = "10.10.0.0/24"
+  ip_cidr_range = "10.10.0.0/16"
 }

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,0 +1,29 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+variable "project_id" {
+  description = "project id"
+}
+
+variable "region" {
+  description = "region"
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+# VPC
+resource "google_compute_network" "vpc" {
+  name                    = "${var.project_id}-zero-prover-vpc"
+  auto_create_subnetworks = "false"
+}
+
+# Subnet
+resource "google_compute_subnetwork" "subnet" {
+  name          = "${var.project_id}-zero-prover-subnet"
+  region        = var.region
+  network       = google_compute_network.vpc.name
+  ip_cidr_range = "10.10.0.0/24"
+}


### PR DESCRIPTION
This PR includes a minimal setup which is identical to the local environment I've used to testing and generating proofs successfully. The quick spin up details are in the readme.

## Deploying GKE with Terraform

The below GKE infrastructure requirement can be automated using the provided terraform scripts under `/terraform` directory.

```!
# First authenticate with your GCP account
gcloud auth application-default login
# Check which project is active and switch as necessary under /terraform/variables.tf
gcloud config get-value project
# Once all the deployment variables have been declared under /terraform/variables.tf start the terraform deployment
terraform init
# Check the predicted deployment outputs
terraform plan
# Deploy the infrastructure
terraform apply
```

With the above instructions, you should have a setup which mimics the below requirement:
- A VPC and a subnet
- GKE cluster and a separately managed node pool