### PR TITLE
feat: add helmfile for helm chart installation

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -1,0 +1,18 @@
+repositories:
+ - name: rabbitmq-cluster-operator
+   url: https://charts.bitnami.com/bitnami
+ - name: kedacore
+   url: https://kedacore.github.io/charts
+
+releases:
+- name: rabbitmq-cluster-operator
+  namespace: rabbitmq-cluster-operator
+  chart: bitnami/rabbitmq-cluster-operator
+  version: 4.3.6
+- name: keda
+  namespace: keda
+  chart: kedacore/keda
+  version: 2.14.2
+- name: test
+  namespace: zero
+  chart: ./helm


### PR DESCRIPTION
Basic helmfile template which as parity with manual installation of the dependencies in readme.
Installing `helmfile` and running:
1. `helmfile init`
2. `helmfile apply`
will install required pods which is also easy to `helmfile destroy` and maintain. This separates the terraform infrastructure deployment from the application deployment and allows quicker testing of devnets.